### PR TITLE
Possible for test duration to be null

### DIFF
--- a/Ghpr.MSTest/TrxReader.cs
+++ b/Ghpr.MSTest/TrxReader.cs
@@ -37,7 +37,7 @@ namespace Ghpr.MSTest
             {
                 var start = DateTime.Parse(utr.GetAttrVal("startTime"));
                 var finish = DateTime.Parse(utr.GetAttrVal("endTime"));
-                var duration = utr.GetAttrVal("duration");
+                var duration = utr.GetAttrVal("duration") ?? "0:00";
                 var testGuid = utr.GetAttrVal("testId") ?? Guid.NewGuid().ToString();
                 var testInfo = new ItemInfo
                 {


### PR DESCRIPTION
Sometimes my tests fail immediately and don't have a test duration/run time which causes the duration variable in TrxReader.cs to be null, which consequently leads to the report not being generated.

This piece of code fails when the `duration` variable is set to null, which throws a **String reference not set to an instance of a String** exception.

**TrxReader.cs**
Line 65: `TestDuration = TimeSpan.Parse(duration).TotalSeconds`